### PR TITLE
Fix wget command

### DIFF
--- a/data_analysis.ipynb
+++ b/data_analysis.ipynb
@@ -125,8 +125,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget\n",
-    "https://aqua.kingcounty.gov/extranet/assessor/Real%20Property%20Sales.zip -P raw_data/"
+    "!wget https://aqua.kingcounty.gov/extranet/assessor/Real%20Property%20Sales.zip -P raw_data/"
    ]
   },
   {


### PR DESCRIPTION
# Overview
* Fixed `wget` command spacing so that no errors would be returned when downloading data from the Internet