### PR TITLE
Fix nominal price hyperlink

### DIFF
--- a/data_analysis.ipynb
+++ b/data_analysis.ipynb
@@ -152,7 +152,9 @@
     "\n",
     "Currently the data lives in a [`.zip`](http://cvs.bio.unc.edu/protocol/unzip-help/unzip-help.htm) file, which is essentially a layer that contains the actual data.\n",
     "\n",
-    "To extract - or unpeel - the contents within the `.zip` file, we'll use the [`unzip`](https://formulae.brew.sh/formula/unzip) command.\n",
+    "To extract - or unpeel - the contents within the `.zip` file, we'll use the [`unzip`](https://formulae.brew.sh/formula/unzip) command. \n",
+    "\n",
+    "By specifying `-d raw_data/`, we're telling `unzip` to place the contents of `raw_data/Real Property Sales.zip` inside the `raw_data/` directory.\n",
     "\n",
     "*If you don't have `unzip`, uncomment the cell below to have `brew` install it for you.*"
    ]
@@ -395,7 +397,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2. After removing the one record that took place in 2021, what is the average [nominal](https://en.wikipedia.org/wiki/Real_versus_nominal_value_(economics)) property sales price in King County, WA?"
+    "### 2. After removing the one record that took place in 2021, what is the average [nominal](https://www.stlouisfed.org/publications/inside-the-vault/fall-2007/nominal-vs-real-oil-prices) property sales price in King County, WA?"
    ]
   },
   {


### PR DESCRIPTION
# Overview
* Fix hyperlink that explains nominal price values
* Add one-liner explaining why `-d raw_data` inside the `unzip` command
* Clear output