### PR TITLE
Clarify question 2

### DIFF
--- a/data_analysis.ipynb
+++ b/data_analysis.ipynb
@@ -165,7 +165,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#brew install unzip"
+    "#!brew install unzip"
    ]
   },
   {
@@ -397,7 +397,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2. After removing the one record that took place in 2021, what is the average [nominal](https://www.stlouisfed.org/publications/inside-the-vault/fall-2007/nominal-vs-real-oil-prices) property sales price in King County, WA?"
+    "### 2. After removing the one record that took place in 2021, what is the annual average [nominal](https://www.stlouisfed.org/publications/inside-the-vault/fall-2007/nominal-vs-real-oil-prices) property sales price in King County, WA?"
    ]
   },
   {


### PR DESCRIPTION
# Overview

* Added the phrase 'annual' so students know to find the average price by year rather than the average price throughout time
* Fixed small typo re: bash command in a jupyter notebook cell. Without the `!` operator, the bash command will not execute.